### PR TITLE
Charges Attributes; new BalanceTransaction; etc.

### DIFF
--- a/lib/Net/Stripe/BalanceTransaction.pm
+++ b/lib/Net/Stripe/BalanceTransaction.pm
@@ -1,0 +1,28 @@
+package Net::Stripe::BalanceTransaction;
+use Moose;
+use Moose::Util::TypeConstraints;
+use methods;
+extends 'Net::Stripe::Resource';
+
+subtype 'TransactionType',
+      as 'Str',
+      where { $_ =~ /^(?:charge|refund|adjustment|application_fee(?:_refund)?|transfer_?(?:cancelfailure)?)$/ },
+      message { "A transaction type must be one of charge, refund, adjustment, application_fee, application_fee_refund, transfer, transfer_cancel or transfer_failure" };
+      
+subtype 'StatusType',
+  as 'Str',
+  where { $_ =~ /^(?:available|pending)$/ },
+  message { "A Status must be one of available or pending" };
+
+has 'id'            => (is => 'ro', isa => 'Str');
+has 'amount'        => (is => 'ro', isa => 'Int');
+has 'currency'      => (is => 'ro', isa => 'Str', required => 1);
+has 'net'           => (is => 'ro', isa => 'Int');
+has 'type'          => (is => 'ro', isa => 'TransactionType');
+has 'created'       => (is => 'ro', isa => 'Int');
+has 'available_on'  => (is => 'ro', isa => 'Int');
+has 'status'        => (is => 'ro', isa => 'StatusType'); 
+has 'fee'           => (is => 'ro', isa => 'Int');
+has 'fee_details'   => (is => 'ro', isa => 'Maybe[ArrayRef]');
+has 'source'        => (is => 'ro', isa => 'Str');
+has 'description'   => (is => 'ro', isa => 'Maybe[Str]');

--- a/lib/Net/Stripe/Charge.pm
+++ b/lib/Net/Stripe/Charge.pm
@@ -3,18 +3,22 @@ use Moose;
 use methods;
 extends 'Net::Stripe::Resource';
 
-has 'id'          => (is => 'ro', isa => 'Maybe[Str]');
-has 'created'     => (is => 'ro', isa => 'Maybe[Int]');
-has 'fee'         => (is => 'ro', isa => 'Maybe[Int]');
-has 'amount'      => (is => 'ro', isa => 'Maybe[Int]', required => 1);
-has 'currency'    => (is => 'ro', isa => 'Maybe[Str]', required => 1);
-has 'customer'    => (is => 'ro', isa => 'Maybe[Str]');
-has 'card'        => (is => 'ro', isa => 'Maybe[StripeCard]');
-has 'description' => (is => 'ro', isa => 'Maybe[Str]');
-has 'livemode'    => (is => 'ro', isa => 'Maybe[Bool]');
-has 'paid'        => (is => 'ro', isa => 'Maybe[Bool]');
-has 'refunded'    => (is => 'ro', isa => 'Maybe[Bool]');
-has 'amount_refunded' => (is => 'ro', isa => 'Maybe[Int]');
+has 'id'                  => (is => 'ro', isa => 'Maybe[Str]');
+has 'created'             => (is => 'ro', isa => 'Maybe[Int]');
+has 'amount'              => (is => 'ro', isa => 'Maybe[Int]', required => 1);
+has 'currency'            => (is => 'ro', isa => 'Maybe[Str]', required => 1);
+has 'customer'            => (is => 'ro', isa => 'Maybe[Str]');
+has 'card'                => (is => 'ro', isa => 'Maybe[StripeCard]');
+has 'description'         => (is => 'ro', isa => 'Maybe[Str]');
+has 'livemode'            => (is => 'ro', isa => 'Maybe[Bool]');
+has 'paid'                => (is => 'ro', isa => 'Maybe[Bool]');
+has 'refunded'            => (is => 'ro', isa => 'Maybe[Bool]');
+has 'amount_refunded'     => (is => 'ro', isa => 'Maybe[Int]');
+has 'captured'            => (is => 'ro', isa => 'Maybe[Bool]');
+has 'balance_transaction' => (is => 'ro', isa => 'Maybe[Str]');
+has 'failure_message'     => (is => 'ro', isa => 'Maybe[Str]');
+has 'failure_code'        => (is => 'ro', isa => 'Maybe[Str]');
+
 
 method form_fields {
     return (


### PR DESCRIPTION
- Note removal of "count" attribute in recent Stripe update to Lists
- new BalanceTransfer Object (contains Stripe fee) …
- allow passing of "created" hashref to _get_collections,
  used for instance to get Charges constrained by dates
- teach hash_to_object() to convert Stripe's underscore_words
  to module's UpperCamelCase
- additional attributes in Charge object
